### PR TITLE
Added ability to send URL request via S3

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.h
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.h
@@ -1,0 +1,227 @@
+// AFAmazonS3Manager.h
+//
+// Copyright (c) 2011–2014 AFNetworking (http://afnetworking.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFHTTPRequestOperationManager.h"
+#import "AFAmazonS3RequestSerializer.h"
+
+/**
+ AFAmazonS3Manager` is an `AFHTTPRequestOperationManager` subclass for interacting with the Amazon S3 webservice API (http://aws.amazon.com/s3/).
+ */
+@interface AFAmazonS3Manager : AFHTTPRequestOperationManager <NSSecureCoding, NSCopying>
+
+/**
+ The base URL for the S3 manager.
+
+ @discussion By default, the `baseURL` of `AFAmazonS3Manager` is derived from the `bucket` and `region` values. If `baseURL` is set directly, it will override the default `baseURL` and disregard values set for the `bucket`, `region`, and `useSSL` properties.
+ */
+@property (readonly, nonatomic, strong) NSURL *baseURL;
+
+/**
+ Requests created by `AFAmazonS3Manager` are serialized by a subclass of `AFAmazonS3RequestSerializer`, which is responsible for encoding credentials, and any specified region and bucket.
+ */
+@property (nonatomic, strong) AFAmazonS3RequestSerializer <AFURLRequestSerialization> * requestSerializer;
+
+/**
+ Initializes and returns a newly allocated Amazon S3 client with specified credentials.
+
+ This is the designated initializer.
+
+ @param accessKey The AWS access key.
+ @param secret The AWS secret.
+ */
+- (id)initWithAccessKeyID:(NSString *)accessKey
+                   secret:(NSString *)secret;
+
+/**
+ Creates and enqueues a request operation to the client's operation queue.
+
+ @param method The HTTP method for the request.
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)enqueueS3RequestOperationWithMethod:(NSString *)method
+                                       path:(NSString *)path
+                                 parameters:(NSDictionary *)parameters
+                                    success:(void (^)(id responseObject))success
+                                    failure:(void (^)(NSError *error))failure;
+
+///-------------------------
+/// @name Service Operations
+///-------------------------
+
+/**
+ Returns a list of all buckets owned by the authenticated request sender.
+
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)getServiceWithSuccess:(void (^)(id responseObject))success
+                      failure:(void (^)(NSError *error))failure;
+
+
+///------------------------
+/// @name Bucket Operations
+///------------------------
+
+/**
+ Lists information about the objects in a bucket for a user that has read access to the bucket.
+
+ @param bucket The S3 bucket to get.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)getBucket:(NSString *)bucket
+          success:(void (^)(id responseObject))success
+          failure:(void (^)(NSError *error))failure;
+
+/**
+ Creates a new bucket belonging to the account of the authenticated request sender. Optionally, you can specify a EU (Ireland) or US-West (N. California) location constraint.
+
+ @param bucket The S3 bucket to create.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)putBucket:(NSString *)bucket
+       parameters:(NSDictionary *)parameters
+          success:(void (^)(id responseObject))success
+          failure:(void (^)(NSError *error))failure;
+
+/**
+ Deletes the specified bucket. All objects in the bucket must be deleted before the bucket itself can be deleted.
+
+ @param bucket The S3 bucket to be delete.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)deleteBucket:(NSString *)bucket
+             success:(void (^)(id responseObject))success
+             failure:(void (^)(NSError *error))failure;
+
+///----------------------------------------------
+/// @name Object Operations
+///----------------------------------------------
+
+/**
+ Retrieves information about an object for a user with read access without fetching the object.
+
+ @param path The object path.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)headObjectWithPath:(NSString *)path
+                   success:(void (^)(NSHTTPURLResponse *response))success
+                   failure:(void (^)(NSError *error))failure;
+
+/**
+ Gets an object for a user that has read access to the object.
+
+ @param path The object path.
+ @param progress A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)getObjectWithPath:(NSString *)path
+                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                  success:(void (^)(id responseObject, NSData *responseData))success
+                  failure:(void (^)(NSError *error))failure;
+
+/**
+ Gets an object for a user that has read access to the object.
+
+ @param path The object path.
+ @param outputStream The `NSOutputStream` object receiving data from the request.
+ @param progress A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)getObjectWithPath:(NSString *)path
+             outputStream:(NSOutputStream *)outputStream
+                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                  success:(void (^)(id responseObject))success
+                  failure:(void (^)(NSError *error))failure;
+
+/**
+ Adds an object to a bucket using forms.
+
+ @param path The path to the local file.
+ @param destinationPath The destination path for the remote file.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param progress A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+
+ @discussion `destinationPath` is relative to the bucket's root, and will create any intermediary directories as necessary. For example, specifying "/a/b/c.txt" will create the "/a" and / or "/a/b" directories within the bucket, if they do not already exist, and upload the source file as "c.txt" into "/a/b".
+ */
+- (void)postObjectWithFile:(NSString *)path
+           destinationPath:(NSString *)destinationPath
+                parameters:(NSDictionary *)parameters
+                  progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                   success:(void (^)(id responseObject))success
+                   failure:(void (^)(NSError *error))failure;
+
+/**
+ Adds an object to a bucket for a user that has write access to the bucket. A success response indicates the object was successfully stored; if the object already exists, it will be overwritten.
+
+ @param path The path to the local file.
+ @param destinationPath The destination path for the remote file, including its name.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param progress A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+
+ @discussion `destinationPath` is relative to the bucket's root, and will create any intermediary directories as necessary. For example, specifying "/a/b/c.txt" will create the "/a" and / or "/a/b" directories within the bucket, if they do not already exist, and upload the source file as "c.txt" into "/a/b".
+ */
+- (void)putObjectWithFile:(NSString *)path
+          destinationPath:(NSString *)destinationPath
+               parameters:(NSDictionary *)parameters
+                 progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                  success:(void (^)(id responseObject))success
+                  failure:(void (^)(NSError *error))failure;
+
+/**
+ Deletes the specified object. Once deleted, there is no method to restore or undelete an object.
+
+ @param path The path for the remote file to be deleted.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ */
+- (void)deleteObjectWithPath:(NSString *)path
+                     success:(void (^)(id responseObject))success
+                     failure:(void (^)(NSError *error))failure;
+
+@end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## Error Domain
+
+ `AFAmazonS3ManagerErrorDomain`
+ AFAmazonS3Manager errors. Error codes for `AFAmazonS3ManagerErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ */
+extern NSString * const AFAmazonS3ManagerErrorDomain;
+
+@compatibility_alias AFAmazonS3Client AFAmazonS3Manager;

--- a/AFAmazonS3Manager/AFAmazonS3Manager.m
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.m
@@ -1,0 +1,295 @@
+// AFAmazonS3Manager.m
+//
+// Copyright (c) 2011–2014 AFNetworking (http://afnetworking.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFAmazonS3Manager.h"
+
+NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.error";
+
+@interface AFAmazonS3Manager ()
+@property (readwrite, nonatomic, strong) NSURL *baseURL;
+@end
+
+@implementation AFAmazonS3Manager
+@synthesize baseURL = _s3_baseURL;
+
+- (instancetype)initWithBaseURL:(NSURL *)url {
+    self = [super initWithBaseURL:url];
+    if (!self) {
+        return nil;
+    }
+
+    self.requestSerializer = [AFAmazonS3RequestSerializer serializer];
+    self.responseSerializer = [AFXMLParserResponseSerializer serializer];
+
+    return self;
+}
+
+- (id)initWithAccessKeyID:(NSString *)accessKey
+                   secret:(NSString *)secret
+{
+    self = [self initWithBaseURL:nil];
+    if (!self) {
+        return nil;
+    }
+
+    [self.requestSerializer setAccessKeyID:accessKey secret:secret];
+
+    return self;
+}
+
+- (NSURL *)baseURL {
+    if (!_s3_baseURL) {
+        return self.requestSerializer.endpointURL;
+    }
+
+    return _s3_baseURL;
+}
+
+#pragma mark -
+
+- (void)enqueueS3RequestOperationWithMethod:(NSString *)method
+                                       path:(NSString *)path
+                                 parameters:(NSDictionary *)parameters
+                                    success:(void (^)(id responseObject))success
+                                    failure:(void (^)(NSError *error))failure
+{
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:path] absoluteString] parameters:parameters error:nil];
+    AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(responseObject);
+        }
+    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+
+    [self.operationQueue addOperation:requestOperation];
+}
+
+
+#pragma mark Service Operations
+
+- (void)getServiceWithSuccess:(void (^)(id responseObject))success
+                      failure:(void (^)(NSError *error))failure
+{
+    [self enqueueS3RequestOperationWithMethod:@"GET" path:@"/" parameters:nil success:success failure:failure];
+}
+
+#pragma mark Bucket Operations
+
+- (void)getBucket:(NSString *)bucket
+          success:(void (^)(id responseObject))success
+          failure:(void (^)(NSError *error))failure
+{
+    [self enqueueS3RequestOperationWithMethod:@"GET" path:bucket parameters:nil success:success failure:failure];
+}
+
+- (void)putBucket:(NSString *)bucket
+       parameters:(NSDictionary *)parameters
+          success:(void (^)(id responseObject))success
+          failure:(void (^)(NSError *error))failure
+{
+    [self enqueueS3RequestOperationWithMethod:@"PUT" path:bucket parameters:parameters success:success failure:failure];
+
+}
+
+- (void)deleteBucket:(NSString *)bucket
+             success:(void (^)(id responseObject))success
+             failure:(void (^)(NSError *error))failure
+{
+    [self enqueueS3RequestOperationWithMethod:@"DELETE" path:bucket parameters:nil success:success failure:failure];
+}
+
+#pragma mark Object Operations
+
+- (void)headObjectWithPath:(NSString *)path
+                   success:(void (^)(NSHTTPURLResponse *response))success
+                   failure:(void (^)(NSError *error))failure
+{
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"HEAD" URLString:[[self.baseURL URLByAppendingPathComponent:path] absoluteString] parameters:nil error:nil];
+    AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, __unused id responseObject) {
+        if (success) {
+            success(operation.response);
+        }
+    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+
+    [self.operationQueue addOperation:requestOperation];
+}
+
+- (void)getObjectWithPath:(NSString *)path
+                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                  success:(void (^)(id responseObject, NSData *responseData))success
+                  failure:(void (^)(NSError *error))failure
+{
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"GET" URLString:[[self.baseURL URLByAppendingPathComponent:path] absoluteString] parameters:nil error:nil];
+    AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(responseObject, operation.responseData);
+        }
+    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+
+    [requestOperation setDownloadProgressBlock:progress];
+
+    [self.operationQueue addOperation:requestOperation];
+}
+
+- (void)getObjectWithPath:(NSString *)path
+             outputStream:(NSOutputStream *)outputStream
+                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                  success:(void (^)(id responseObject))success
+                  failure:(void (^)(NSError *error))failure
+{
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"GET" URLString:[[self.baseURL URLByAppendingPathComponent:path] absoluteString] parameters:nil error:nil];
+    AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(responseObject);
+        }
+    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+
+    requestOperation.outputStream = outputStream;
+
+    [requestOperation setDownloadProgressBlock:progress];
+
+    [self.operationQueue addOperation:requestOperation];
+}
+
+- (void)postObjectWithFile:(NSString *)path
+           destinationPath:(NSString *)destinationPath
+                parameters:(NSDictionary *)parameters
+                  progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                   success:(void (^)(id responseObject))success
+                   failure:(void (^)(NSError *error))failure
+{
+    [self setObjectWithMethod:@"POST" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
+}
+
+- (void)putObjectWithFile:(NSString *)path
+          destinationPath:(NSString *)destinationPath
+               parameters:(NSDictionary *)parameters
+                 progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                  success:(void (^)(id responseObject))success
+                  failure:(void (^)(NSError *error))failure
+{
+    [self setObjectWithMethod:@"PUT" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
+}
+
+- (void)deleteObjectWithPath:(NSString *)path
+                     success:(void (^)(id responseObject))success
+                     failure:(void (^)(NSError *error))failure
+{
+    [self enqueueS3RequestOperationWithMethod:@"DELETE" path:path parameters:nil success:success failure:failure];
+}
+
+- (void)setObjectWithMethod:(NSString *)method
+                       file:(NSString *)filePath
+            destinationPath:(NSString *)destinationPath
+                 parameters:(NSDictionary *)parameters
+                   progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                    success:(void (^)(id responseObject))success
+                    failure:(void (^)(NSError *error))failure
+{
+    NSMutableURLRequest *fileRequest = [NSMutableURLRequest requestWithURL:[NSURL fileURLWithPath:filePath]];
+    fileRequest.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+
+    NSURLResponse *response = nil;
+    NSError *fileError = nil;
+    NSData *data = [NSURLConnection sendSynchronousRequest:fileRequest returningResponse:&response error:&fileError];
+
+    if (fileError || !response || !data) {
+        if (failure) {
+            failure(fileError);
+        }
+
+        return;
+    }
+
+    destinationPath = [destinationPath stringByReplacingOccurrencesOfString:@" " withString:@"+"];
+
+    NSMutableURLRequest *request = nil;
+    if ([method compare:@"POST" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        NSError *requestError = nil;
+        request = [self.requestSerializer multipartFormRequestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:parameters constructingBodyWithBlock:^(id <AFMultipartFormData> formData) {
+            if (![parameters valueForKey:@"key"]) {
+                [formData appendPartWithFormData:[[filePath lastPathComponent] dataUsingEncoding:NSUTF8StringEncoding] name:@"key"];
+            }
+
+            [formData appendPartWithFileData:data name:@"file" fileName:[filePath lastPathComponent] mimeType:[response MIMEType]];
+        } error:&requestError];
+
+        if (requestError || !request) {
+            if (failure) {
+                failure(requestError);
+            }
+            
+            return;
+        }
+    } else {
+        request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:parameters error:nil];
+        request.HTTPBody = data;
+    }
+
+    AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(responseObject);
+        }
+    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+
+    [requestOperation setUploadProgressBlock:progress];
+
+    [self.operationQueue addOperation:requestOperation];
+}
+
+#pragma mark - NSKeyValueObserving
+
++ (NSSet *)keyPathsForValuesAffectingBaseURL {
+    return [NSSet setWithObjects:@"baseURL", @"requestSerializer.bucket", @"requestSerializer.region", @"requestSerializer.useSSL", nil];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    AFAmazonS3Manager *manager = [[[self class] allocWithZone:zone] initWithBaseURL:_s3_baseURL];
+
+    manager.requestSerializer = [self.requestSerializer copyWithZone:zone];
+    manager.responseSerializer = [self.responseSerializer copyWithZone:zone];
+
+    return manager;
+}
+
+@end

--- a/AFAmazonS3Manager/AFAmazonS3RequestSerializer.h
+++ b/AFAmazonS3Manager/AFAmazonS3RequestSerializer.h
@@ -1,0 +1,125 @@
+// AFAmazonS3RequestSerializer.h
+//
+// Copyright (c) 2011–2014 AFNetworking (http://afnetworking.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFURLRequestSerialization.h"
+
+/**
+ `AFAmazonS3RequestSerializer` is an `AFHTTPRequestSerializer` subclass with convenience methods for creating requests for the Amazon S3 webservice, including creating an authorization header and building an endpoint URL for a given bucket, region, and TLS preferences.
+ */
+@interface AFAmazonS3RequestSerializer : AFHTTPRequestSerializer
+
+/**
+ The S3 bucket for the client. `nil` by default.
+
+ @see `AFAmazonS3Manager -baseURL`
+ */
+@property (nonatomic, copy) NSString *bucket;
+
+/**
+ The AWS region for the client. `AFAmazonS3USStandardRegion` by default. Must not be `nil`. See "AWS Regions" for defined constant values.
+
+ @see `AFAmazonS3Manager -baseURL`
+ */
+@property (nonatomic, copy) NSString *region;
+
+/**
+ The AWS STS session token. `nil` by default.
+ */
+@property (nonatomic, copy) NSString *sessionToken;
+
+/**
+ Whether to connect over HTTPS. `YES` by default.
+
+ @see `AFAmazonS3Manager -baseURL`
+ */
+@property (nonatomic, assign) BOOL useSSL;
+
+/**
+ A readonly endpoint URL created for the specified bucket, region, and TLS preference. `AFAmazonS3Manager` uses this as a `baseURL` unless one is manually specified.
+ */
+@property (readonly, nonatomic, copy) NSURL *endpointURL;
+
+/**
+ Sets the access key ID and secret, used to generate authorization headers.
+
+ @param accessKey The Amazon S3 Access Key ID.
+ @param secret The Amazon S3 Secret.
+
+ @discussion These values can be found on the AWS control panel: http://aws-portal.amazon.com/gp/aws/developer/account/index.html?action=access-key
+ */
+- (void)setAccessKeyID:(NSString *)accessKey
+                secret:(NSString *)secret;
+
+/**
+ Returns a request with the necessary AWS authorization HTTP header fields from the specified request using the provided credentials.
+
+ @param request The request.
+ @param error The error that occured while constructing the request.
+
+ @return The request with necessary `Authorization` and `Date` HTTP header fields.
+ */
+- (NSURLRequest *)requestBySettingAuthorizationHeadersForRequest:(NSURLRequest *)request
+                                                           error:(NSError * __autoreleasing *)error;
+
+/**
+ Returns a request with pre-signed credentials in the query string.
+
+ @param request The request. `HTTPMethod` must be `GET`.
+ @param expiration The request expiration. If `nil`, defaults to 1 hour from when method is called.
+ @param error The error that occured while constructing the request.
+
+ @return The request with credentials signed in query string.
+ */
+- (NSURLRequest *)preSignedRequestWithRequest:(NSURLRequest *)request
+                                   expiration:(NSDate *)expiration
+                                        error:(NSError * __autoreleasing *)error;
+
+@end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## AWS Regions
+
+ The following AWS regions are defined:
+
+ `AFAmazonS3USStandardRegion`: US Standard (s3.amazonaws.com);
+ `AFAmazonS3USWest1Region`: US West (Oregon) Region (s3-us-west-1.amazonaws.com)
+ `AFAmazonS3USWest2Region`: US West (Northern California) Region (s3-us-west-2.amazonaws.com)
+ `AFAmazonS3EUWest1Region`: EU (Ireland) Region (s3-eu-west-1.amazonaws.com)
+ `AFAmazonS3APSoutheast1Region`: Asia Pacific (Singapore) Region (s3-ap-southeast-1.amazonaws.com)
+ `AFAmazonS3APSoutheast2Region`: Asia Pacific (Sydney) Region (s3-ap-southeast-2.amazonaws.com)
+ `AFAmazonS3APNortheast2Region`: Asia Pacific (Tokyo) Region (s3-ap-northeast-1.amazonaws.com)
+ `AFAmazonS3SAEast1Region`: South America (Sao Paulo) Region (s3-sa-east-1.amazonaws.com)
+
+ For a full list of available regions, see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+ */
+extern NSString * const AFAmazonS3USStandardRegion;
+extern NSString * const AFAmazonS3USWest1Region;
+extern NSString * const AFAmazonS3USWest2Region;
+extern NSString * const AFAmazonS3EUWest1Region;
+extern NSString * const AFAmazonS3APSoutheast1Region;
+extern NSString * const AFAmazonS3APSoutheast2Region;
+extern NSString * const AFAmazonS3APNortheast2Region;
+extern NSString * const AFAmazonS3SAEast1Region;

--- a/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
+++ b/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
@@ -1,0 +1,264 @@
+// AFAmazonS3RequestSerializer.m
+//
+// Copyright (c) 2011–2014 AFNetworking (http://afnetworking.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFAmazonS3RequestSerializer.h"
+#import "AFAmazonS3Manager.h"
+
+#import <CommonCrypto/CommonHMAC.h>
+
+NSString * const AFAmazonS3USStandardRegion = @"s3.amazonaws.com";
+NSString * const AFAmazonS3USWest1Region = @"s3-us-west-1.amazonaws.com";
+NSString * const AFAmazonS3USWest2Region = @"s3-us-west-2.amazonaws.com";
+NSString * const AFAmazonS3EUWest1Region = @"s3-eu-west-1.amazonaws.com";
+NSString * const AFAmazonS3APSoutheast1Region = @"s3-ap-southeast-1.amazonaws.com";
+NSString * const AFAmazonS3APSoutheast2Region = @"s3-ap-southeast-2.amazonaws.com";
+NSString * const AFAmazonS3APNortheast2Region = @"s3-ap-northeast-1.amazonaws.com";
+NSString * const AFAmazonS3SAEast1Region = @"s3-sa-east-1.amazonaws.com";
+
+static NSTimeInterval const AFAmazonS3DefaultExpirationTimeInterval = 60 * 60;
+
+static NSData * AFHMACSHA1EncodedDataFromStringWithKey(NSString *string, NSString *key) {
+    NSData *data = [string dataUsingEncoding:NSASCIIStringEncoding];
+    CCHmacContext context;
+    const char *keyCString = [key cStringUsingEncoding:NSASCIIStringEncoding];
+
+    CCHmacInit(&context, kCCHmacAlgSHA1, keyCString, strlen(keyCString));
+    CCHmacUpdate(&context, [data bytes], [data length]);
+
+    unsigned char digestRaw[CC_SHA1_DIGEST_LENGTH];
+    NSUInteger digestLength = CC_SHA1_DIGEST_LENGTH;
+
+    CCHmacFinal(&context, digestRaw);
+
+    return [NSData dataWithBytes:digestRaw length:digestLength];
+}
+
+static NSString * AFRFC822FormatStringFromDate(NSDate *date) {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+    [dateFormatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss z"];
+    [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
+
+    return [dateFormatter stringFromDate:date];
+}
+
+static NSString * AFBase64EncodedStringFromData(NSData *data) {
+    NSUInteger length = [data length];
+    NSMutableData *mutableData = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
+
+    uint8_t *input = (uint8_t *)[data bytes];
+    uint8_t *output = (uint8_t *)[mutableData mutableBytes];
+
+    for (NSUInteger i = 0; i < length; i += 3) {
+        NSUInteger value = 0;
+        for (NSUInteger j = i; j < (i + 3); j++) {
+            value <<= 8;
+            if (j < length) {
+                value |= (0xFF & input[j]);
+            }
+        }
+
+        static uint8_t const kAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        NSUInteger idx = (i / 3) * 4;
+        output[idx + 0] = kAFBase64EncodingTable[(value >> 18) & 0x3F];
+        output[idx + 1] = kAFBase64EncodingTable[(value >> 12) & 0x3F];
+        output[idx + 2] = (i + 1) < length ? kAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
+        output[idx + 3] = (i + 2) < length ? kAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
+    }
+
+    return [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
+}
+
+static NSString * AFAWSSignatureForRequest(NSURLRequest *request, NSString *bucket, NSString *timestamp, NSString *key) {
+    NSMutableDictionary *mutableAMZHeaderFields = [NSMutableDictionary dictionary];
+    [[request allHTTPHeaderFields] enumerateKeysAndObjectsUsingBlock:^(NSString *field, id value, __unused BOOL *stop) {
+        field = [field lowercaseString];
+        if ([field hasPrefix:@"x-amz"]) {
+            if ([mutableAMZHeaderFields objectForKey:field]) {
+                value = [[mutableAMZHeaderFields objectForKey:field] stringByAppendingFormat:@",%@", value];
+            }
+            [mutableAMZHeaderFields setObject:value forKey:field];
+        }
+    }];
+
+    NSMutableString *mutableCanonicalizedAMZHeaderString = [NSMutableString string];
+    for (NSString *field in [[mutableAMZHeaderFields allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+        id value = [mutableAMZHeaderFields objectForKey:field];
+        [mutableCanonicalizedAMZHeaderString appendFormat:@"%@:%@\n", field, value];
+    }
+
+    NSString *canonicalizedResource = bucket ? [NSString stringWithFormat:@"/%@%@", bucket, request.URL.path] : request.URL.path;
+    NSString *method = [request HTTPMethod];
+    NSString *contentMD5 = [request valueForHTTPHeaderField:@"Content-MD5"];
+    NSString *contentType = [request valueForHTTPHeaderField:@"Content-Type"];
+
+    NSMutableString *mutableString = [NSMutableString string];
+    [mutableString appendFormat:@"%@\n", method ? method : @""];
+    [mutableString appendFormat:@"%@\n", contentMD5 ? contentMD5 : @""];
+    [mutableString appendFormat:@"%@\n", contentType ? contentType : @""];
+    [mutableString appendFormat:@"%@\n", timestamp ? timestamp : @""];
+    [mutableString appendFormat:@"%@", mutableCanonicalizedAMZHeaderString];
+    [mutableString appendFormat:@"%@", canonicalizedResource];
+
+    return AFBase64EncodedStringFromData(AFHMACSHA1EncodedDataFromStringWithKey(mutableString, key));
+}
+
+@interface AFAmazonS3RequestSerializer ()
+@property (readwrite, nonatomic, copy) NSString *accessKey;
+@property (readwrite, nonatomic, copy) NSString *secret;
+@end
+
+@implementation AFAmazonS3RequestSerializer
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.region = AFAmazonS3USStandardRegion;
+    self.useSSL = YES;
+
+    return self;
+}
+
+- (void)setAccessKeyID:(NSString *)accessKey
+                secret:(NSString *)secret
+{
+    NSParameterAssert(accessKey);
+    NSParameterAssert(secret);
+
+    self.accessKey = accessKey;
+    self.secret = secret;
+}
+
+- (void)setRegion:(NSString *)region {
+    NSParameterAssert(region);
+    _region = region;
+}
+
+- (NSURL *)endpointURL {
+    NSString *URLString = nil;
+    NSString *scheme = self.useSSL ? @"https" : @"http";
+    if (self.bucket) {
+        URLString = [NSString stringWithFormat:@"%@://%@.%@", scheme, self.bucket, self.region];
+    } else {
+        URLString = [NSString stringWithFormat:@"%@://%@", scheme, self.region];
+    }
+
+    return [NSURL URLWithString:URLString];
+}
+
+#pragma mark -
+
+- (NSURLRequest *)requestBySettingAuthorizationHeadersForRequest:(NSURLRequest *)request
+                                                           error:(NSError * __autoreleasing *)error
+{
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+
+    if (self.accessKey && self.secret) {
+        NSDate *date = [NSDate date];
+        NSString *signature = AFAWSSignatureForRequest(request, self.bucket, AFRFC822FormatStringFromDate(date), self.secret);
+
+        [mutableRequest setValue:[NSString stringWithFormat:@"AWS %@:%@", self.accessKey, signature] forHTTPHeaderField:@"Authorization"];
+        [mutableRequest setValue:date ? AFRFC822FormatStringFromDate(date) : @"" forHTTPHeaderField:@"Date"];
+    } else {
+        if (error) {
+            NSDictionary *userInfo = @{
+                                       NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"Access Key and Secret Required", @"AFAmazonS3Manager", nil)
+                                       };
+
+            *error = [[NSError alloc] initWithDomain:AFAmazonS3ManagerErrorDomain code:NSURLErrorUserAuthenticationRequired userInfo:userInfo];
+        }
+    }
+
+    return mutableRequest;
+}
+
+- (NSURLRequest *)preSignedRequestWithRequest:(NSURLRequest *)request
+                                   expiration:(NSDate *)expiration
+                                        error:(NSError * __autoreleasing *)error
+{
+    NSParameterAssert(request);
+    NSParameterAssert([request.HTTPMethod compare:@"GET" options:NSCaseInsensitiveSearch] == NSOrderedSame);
+
+    if (!expiration) {
+        expiration = [[NSDate date] dateByAddingTimeInterval:AFAmazonS3DefaultExpirationTimeInterval];
+    }
+
+    if (self.accessKey) {
+        NSString *expires = @([expiration timeIntervalSince1970]).stringValue;
+        NSString *signature = AFAWSSignatureForRequest(request, self.bucket, expires, self.accessKey);
+
+        NSDictionary *parameters = @{
+                                     @"AWSAccessKeyId": self.accessKey,
+                                     @"Expires": expires,
+                                     @"Signature": signature
+                                    };
+
+        return [self requestBySerializingRequest:request withParameters:parameters error:error];
+    } else {
+        if (error) {
+            NSDictionary *userInfo = @{
+                                       NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"Access Key required", @"AFAmazonS3Manager", nil)
+                                       };
+
+            *error = [[NSError alloc] initWithDomain:AFAmazonS3ManagerErrorDomain code:NSURLErrorUserAuthenticationRequired userInfo:userInfo];
+        }
+
+        return nil;
+    }
+}
+
+#pragma mark - AFHTTPRequestSerializer
+
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                 URLString:(NSString *)URLString
+                                parameters:(NSDictionary *)parameters
+                                     error:(NSError *__autoreleasing *)error
+{
+    NSMutableURLRequest *request = [super requestWithMethod:method URLString:URLString parameters:parameters error:error];
+
+    if (self.sessionToken) {
+        [request setValue:self.sessionToken forHTTPHeaderField:@"x-amz-security-token"];
+    }
+
+    return [[self requestBySettingAuthorizationHeadersForRequest:request error:error] mutableCopy];
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters
+                              constructingBodyWithBlock:(void (^)(id<AFMultipartFormData>))block
+                                                  error:(NSError *__autoreleasing *)error
+{
+    NSMutableURLRequest *request = [super multipartFormRequestWithMethod:method URLString:URLString parameters:parameters constructingBodyWithBlock:block error:error];
+
+    if (self.sessionToken) {
+        [request setValue:self.sessionToken forHTTPHeaderField:@"x-amz-security-token"];
+    }
+
+    return [[self requestBySettingAuthorizationHeadersForRequest:request error:error] mutableCopy];
+}
+
+@end

--- a/PAAImageView.h
+++ b/PAAImageView.h
@@ -7,6 +7,10 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "AFAmazonS3Manager.h"
+#import <AWSiOSSDKv2/S3.h>
+#import <AWSiOSSDKv2/AWSS3TransferManager.h>
+
 
 @protocol PAAImageViewDelegate <NSObject>
 @optional
@@ -30,4 +34,6 @@
 
 - (void)setBackgroundWidth:(CGFloat)width;
 
+//for S3
+-(void)setAmazonAcessKey:(NSString*)yourAWSAcessKey and:(NSString*)yourAWSSecretKey and:(NSString*)yourAWSBucketKey and:(NSString*)s3_link;
 @end

--- a/PAAImageView.h
+++ b/PAAImageView.h
@@ -7,9 +7,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "AFAmazonS3Manager.h"
-#import <AWSiOSSDKv2/S3.h>
-#import <AWSiOSSDKv2/AWSS3TransferManager.h>
 
 
 @protocol PAAImageViewDelegate <NSObject>

--- a/PAAImageView.h
+++ b/PAAImageView.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-
+#import "AFAmazonS3RequestSerializer.h"
 
 @protocol PAAImageViewDelegate <NSObject>
 @optional
@@ -33,5 +33,15 @@
 
 //for S3
 -(void)setS3ImageLink:(NSString*)s3_link withAccessKey:(NSString *)accessKey withBucketKey:(NSString*)bucketKey withSecretKey:(NSString*)secretKey;
+@property (nonatomic, strong) NSString* region; //default is AFAmazonS3USWest1Region
 
 @end
+
+extern NSString * const AFAmazonS3USStandardRegion;
+extern NSString * const AFAmazonS3USWest1Region;
+extern NSString * const AFAmazonS3USWest2Region;
+extern NSString * const AFAmazonS3EUWest1Region;
+extern NSString * const AFAmazonS3APSoutheast1Region;
+extern NSString * const AFAmazonS3APSoutheast2Region;
+extern NSString * const AFAmazonS3APNortheast2Region;
+extern NSString * const AFAmazonS3SAEast1Region;

--- a/PAAImageView.h
+++ b/PAAImageView.h
@@ -32,5 +32,6 @@
 - (void)setBackgroundWidth:(CGFloat)width;
 
 //for S3
--(void)setAmazonAcessKey:(NSString*)yourAWSAcessKey and:(NSString*)yourAWSSecretKey and:(NSString*)yourAWSBucketKey and:(NSString*)s3_link;
+-(void)setS3ImageLink:(NSString*)s3_link withAccessKey:(NSString *)accessKey withBucketKey:(NSString*)bucketKey withSecretKey:(NSString*)secretKey;
+
 @end

--- a/PAAImageView.m
+++ b/PAAImageView.m
@@ -202,18 +202,19 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
     }
 }
 
--(void)setAmazonAcessKey:(NSString*)yourAWSAcessKey and:(NSString*)yourAWSSecretKey and:(NSString*)yourAWSBucketKey and:(NSString*)s3_link{
+-(void)setS3ImageLink:(NSString*)s3_link withAccessKey:(NSString *)accessKey withBucketKey:(NSString*)bucketKey withSecretKey:(NSString*)secretKey{
     
-    UIImage *cachedImage = (self.cacheEnabled) ? [self.cache getImageForURL:s3_link] : nil;
+    NSURL *url = [NSURL URLWithString:s3_link];
+    
+    UIImage *cachedImage = (self.cacheEnabled) ? [self.cache getImageForURL:url] : nil;
     if(cachedImage)
     {
         [self updateWithImage:cachedImage animated:NO];
     }
     else{
-        AFAmazonS3Manager *s3Manager = [[AFAmazonS3Manager alloc] initWithAccessKeyID:yourAWSAcessKey secret:yourAWSSecretKey];
+        AFAmazonS3Manager *s3Manager = [[AFAmazonS3Manager alloc] initWithAccessKeyID:accessKey secret:secretKey];
         s3Manager.requestSerializer.region = AFAmazonS3USWest1Region;
-        s3Manager.requestSerializer.bucket = yourAWSBucketKey;
-        s3Manager.responseSerializer = [AFImageResponseSerializer serializer];
+        s3Manager.requestSerializer.bucket = bucketKey;
         s3Manager.responseSerializer = [AFImageResponseSerializer serializer];
         NSSet *set = s3Manager.responseSerializer.acceptableContentTypes;
         s3Manager.responseSerializer.acceptableContentTypes = [set setByAddingObject:@"binary/octet-stream"];
@@ -221,7 +222,6 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
         __weak __typeof(self)weakSelf = self;
         
         [s3Manager getObjectWithPath:s3_link progress:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
-            NSLog(@"%u", bytesRead);
             CGFloat progress = (CGFloat)totalBytesRead/(CGFloat)totalBytesExpectedToRead;
             
             self.progressLayer.strokeEnd        = progress;
@@ -234,11 +234,10 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
             
             if(self.cacheEnabled)
             {
-                [self.cache setImage:responseObject forURL:s3_link];
+                [self.cache setImage:responseObject forURL:url];
             }
             
         } failure:^(NSError *error) {
-            NSLog(@"%@", error);
         }];
     }
 }

--- a/PAAImageView.m
+++ b/PAAImageView.m
@@ -13,7 +13,6 @@
 #import <AWSiOSSDKv2/AWSS3TransferManager.h>
 
 
-
 #pragma mark - Utils
 
 #define rad(degrees) ((degrees) / (180.0 / M_PI))
@@ -65,8 +64,8 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
 - (id)initWithFrame:(CGRect)frame
 {
     return [[PAAImageView alloc] initWithFrame:frame
-                      backgroundProgressColor:[UIColor whiteColor]
-                                progressColor:[UIColor blueColor]];
+                       backgroundProgressColor:[UIColor whiteColor]
+                                 progressColor:[UIColor blueColor]];
 }
 
 - (id)initWithFrame:(CGRect)frame backgroundProgressColor:(UIColor *)backgroundProgresscolor progressColor:(UIColor *)progressColor
@@ -213,11 +212,15 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
     }
     else{
         AFAmazonS3Manager *s3Manager = [[AFAmazonS3Manager alloc] initWithAccessKeyID:accessKey secret:secretKey];
-        s3Manager.requestSerializer.region = AFAmazonS3USWest1Region;
         s3Manager.requestSerializer.bucket = bucketKey;
         s3Manager.responseSerializer = [AFImageResponseSerializer serializer];
         NSSet *set = s3Manager.responseSerializer.acceptableContentTypes;
         s3Manager.responseSerializer.acceptableContentTypes = [set setByAddingObject:@"binary/octet-stream"];
+        
+        if(self.region != nil){
+            s3Manager.requestSerializer.region = self.region;}
+        else{
+            s3Manager.requestSerializer.region = AFAmazonS3USWest1Region;}
         
         __weak __typeof(self)weakSelf = self;
         
@@ -300,7 +303,7 @@ NSString * const paa_identifier = @"paa.imagecache.tg";
     {
         NSArray  *paths         = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         NSString *rootCachePath = [paths firstObject];
-
+        
         self.fileManager    = [NSFileManager defaultManager];
         self.cachePath      = [rootCachePath stringByAppendingPathComponent:paa_identifier];
         

--- a/PAAImageView.m
+++ b/PAAImageView.m
@@ -8,6 +8,11 @@
 
 #import "PAAImageView.h"
 #import "AFNetworking/AFNetworking.h"
+#import "AFAmazonS3Manager.h"
+#import <AWSiOSSDKv2/S3.h>
+#import <AWSiOSSDKv2/AWSS3TransferManager.h>
+
+
 
 #pragma mark - Utils
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PAAImageView *avatarView = [[PAAImageView alloc] initWithFrame:aFrame background
 // Later, can send simple URL request OR Amazon S3
 
 [avatarView setImageURL:URL]; //URL
-[avatarView setAmazonAcessKey:AWS_Access_Key and:AWS_Secret_Key and:AWS_Bucket_Name and:tempDetail.customer.s3_link]; //via S3
+[avatarView setS3ImageLink:tempDetail.customer.s3_link withAccessKey:AWS_Access_Key withBucketKey:AWS_Bucket_Name withSecretKey:AWS_Secret_Key];
 ```
 
 ## Update

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ PAAImageView *avatarView = [[PAAImageView alloc] initWithFrame:aFrame background
 
 [avatarView setImageURL:URL]; //URL
 [avatarView setS3ImageLink:tempDetail.customer.s3_link withAccessKey:AWS_Access_Key withBucketKey:AWS_Bucket_Name withSecretKey:AWS_Secret_Key];
+ avatarView.region = AFAmazonS3USWest2Region; //default is AFAmazonS3USWest1Region
 ```
 
 ## Update

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@
 ```objective-c
 PAAImageView *avatarView = [[PAAImageView alloc] initWithFrame:aFrame backgroundProgressColor:[UIColor whiteColor] progressColor:[UIColor lightGrayColor]];
 [self.view addSubview:avatarView];
-// Later
-[avatarView setImageURL:URL];
+ 
+// Later, can send simple URL request OR Amazon S3
+
+[avatarView setImageURL:URL]; //URL
+[avatarView setAmazonAcessKey:AWS_Access_Key and:AWS_Secret_Key and:AWS_Bucket_Name and:tempDetail.customer.s3_link]; //via S3
 ```
 
 ## Update
@@ -31,7 +34,7 @@ You need use next method for load from resource
 **That's all**
 
 ## Contact
-
+[Solomon Bier] (https://github.com/SolomonBier)
 [Pierre Abi-aad](http://github.com/abiaad)
 [@abiaad](https://twitter.com/abiaad)
 


### PR DESCRIPTION
For those using S3 (realistically a large # of people), then they can request by passing their credentials via: 

-(void)setAmazonAcessKey:(NSString_)yourAWSAcessKey and:(NSString_)yourAWSSecretKey and:(NSString_)yourAWSBucketKey and:(NSString_)s3_link;

This accepts all content types, including binary/octect-stream ! 

I included AFAmazonS3 manager as well. Those already using this can ignore these source files/folder 
